### PR TITLE
Change store initialization

### DIFF
--- a/src/models/Store.js
+++ b/src/models/Store.js
@@ -4,9 +4,24 @@ import Model          from './Model';
 
 export default class Store extends Model {
 
-  constructor({ models = [], state = {} }) {
-    super(state);
-    this._initModelNamesHash(models);
+  //==================
+  // CLASS PROPERTIES
+  //==================
+
+  static models = [];
+  static modelsHash = {};
+
+
+  //===============
+  // CLASS METHODS
+  //===============
+
+  static setModelRefs(models) {
+    Store.models = models;
+    Store.modelsHash = models.reduce((hash, model) => {
+      hash[model.name] = model;
+      return hash;
+    }, {});
   }
 
 
@@ -31,15 +46,8 @@ export default class Store extends Model {
   // INTERNAL METHODS
   //==================
 
-  _initModelNamesHash(models) {
-    this.modelsHash = models.reduce((hash, model) => {
-      hash[model.name] = model;
-      return hash;
-    }, {});
-  }
-
   _createModelsHash() {
-    return Object.keys(this.modelsHash).reduce((hash, key) => {
+    return Object.keys(Store.modelsHash).reduce((hash, key) => {
       hash[key] = {};
       return hash;
     }, {});
@@ -110,7 +118,7 @@ export default class Store extends Model {
       return newModelHash[_id];
     }
 
-    const newModel = new this.modelsHash[_constructor](
+    const newModel = new Store.modelsHash[_constructor](
       this._fromSerial(models[_constructor][_id], models, newModels)
     );
 

--- a/tests/models/Store.test.js
+++ b/tests/models/Store.test.js
@@ -95,16 +95,19 @@ list2.setOtherList(list1);
 describe('Store', () => {
   let store;
   let state;
-  let models;
   let output;
+
+  beforeEach(() => {
+    Store.setModelRefs([ List, ListItem ]);
+  });
 
   describe('parse', () => {
     describe('with non-Model data', () => {
       beforeEach(() => {
         state = { string, number, float, bool, array, object };
-        store = new Store({ state });
+        store = new Store(state);
         output = store.stringify();
-        store = new Store({});
+        store = new Store();
         store.parse(output);
       });
 
@@ -115,11 +118,10 @@ describe('Store', () => {
 
     describe('with Model data', () => {
       beforeEach(() => {
-        models = [List, ListItem];
         state = { list: list1, otherList: list2 };
-        store = new Store({ models, state });
+        store = new Store(state);
         output = store.stringify();
-        store = new Store({ models });
+        store = new Store();
         Model.baseId = 1;
         store.parse(output);
       });


### PR DESCRIPTION
Why:
- It doesn't make sense to have to pass in all model classes per instance of store.

Changes:
- Create `setModelRefs` class method for `Store` that keeps a references of all model classes used.