### PR TITLE
 Create empty state object for defined entities

### DIFF
--- a/lib/models/Store.js
+++ b/lib/models/Store.js
@@ -5,9 +5,11 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var _isPlainObject = _interopRequireDefault(require("lodash/isPlainObject"));
-
 var _find = _interopRequireDefault(require("lodash/find"));
+
+var _isUndefined = _interopRequireDefault(require("lodash/isUndefined"));
+
+var _isPlainObject = _interopRequireDefault(require("lodash/isPlainObject"));
 
 var _map = _interopRequireDefault(require("lodash/map"));
 
@@ -153,6 +155,10 @@ function (_Model) {
     value: function _createEntityHelper(key) {
       var cappedKey = key[0].toUpperCase() + key.substring(1);
       var findKey = "find".concat(cappedKey);
+
+      if ((0, _isUndefined["default"])(this.state[key])) {
+        this.state[key] = {};
+      }
 
       if ((0, _isPlainObject["default"])(this.state[key])) {
         this.constructor.prototype[findKey] = this[findKey] || function (id) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-axiom",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "React Axiom is a way to use models with React.",
   "repository": "https://github.com/wgoto/react-axiom",
   "main": "lib/index.js",

--- a/src/models/Store.js
+++ b/src/models/Store.js
@@ -1,5 +1,6 @@
-import isPlainObject  from 'lodash/isPlainObject';
 import find           from 'lodash/find';
+import isUndefined    from 'lodash/isUndefined';
+import isPlainObject  from 'lodash/isPlainObject';
 import map            from 'lodash/map';
 import mapValues      from 'lodash/mapValues';
 import omit           from 'lodash/omit';
@@ -91,6 +92,10 @@ class Store extends Model {
   _createEntityHelper(key) {
     const cappedKey = key[0].toUpperCase() + key.substring(1);
     const findKey = `find${cappedKey}`;
+
+    if (isUndefined(this.state[key])) {
+      this.state[key] = {};
+    }
 
     if (isPlainObject(this.state[key])) {
       this.constructor.prototype[findKey] = this[findKey] || function (id) {

--- a/tests/models/Store.test.js
+++ b/tests/models/Store.test.js
@@ -107,7 +107,7 @@ describe('Store', () => {
   describe('parse', () => {
     describe('with non-Model data', () => {
       beforeEach(() => {
-        state = { string, number, float, bool, array, object, entityDefinitions };
+        state = { string, number, float, bool, array, object, entityDefinitions, listItems: {}, lists: {} };
         store = new Store(state);
         output = store.stringify();
         store = new Store({ entityDefinitions });
@@ -226,7 +226,7 @@ describe('Store', () => {
   describe('parseMerge', () => {
     beforeEach(() => {
       subState = { number, float, bool, array, object };
-      state = { string, number, float, bool, array, object, entityDefinitions };
+      state = { string, number, float, bool, array, object, entityDefinitions, listItems: {}, lists: {} };
       store = new Store(subState);
       output = store.stringify();
       store = new Store({ string, number: {}, entityDefinitions });
@@ -303,6 +303,7 @@ describe('Store', () => {
         entityDefinitions: {
           listItems: ListItem,
           lists: List,
+          newEntity: {},
           falseEntity: {}
         },
         listItems: {
@@ -311,7 +312,8 @@ describe('Store', () => {
         },
         lists: {
           1: list1,
-        }
+        },
+        falseEntity: false
       };
 
       store = new Store(state);
@@ -332,6 +334,16 @@ describe('Store', () => {
     describe('when a false entity is not correctly stored', () => {
       it('should not define a find function', () => {
         expect(store.findFalseEntity).not.toBeDefined();
+      });
+    });
+
+    describe('when a new entity is not stored', () => {
+      it('should create an findNewEntity function', () => {
+        expect(store.findNewEntity).toBeDefined();
+      });
+
+      it('should create an empty object for the new entity', () => {
+        expect(store.state.newEntity).toEqual({});
       });
     });
   });


### PR DESCRIPTION
If an entity is defined for a store, the default behavior should be that it creates a key for it in state set to an empty object (unless that key exists and is not a plain object).